### PR TITLE
use setImmediate instead of process.nextTick

### DIFF
--- a/ac.js
+++ b/ac.js
@@ -34,12 +34,12 @@ AsyncCache.prototype.get = function(key, cb) {
   var has = this._cache.has(key);
   var cached = this._cache.get(key);
   if (has && void 0 !== cached)
-    return process.nextTick(function() {
+    return setImmediate(function() {
       cb(null, cached);
     });
 
   if (void 0 !== cached && this._allowStale && !has)
-    process.nextTick(function() {
+    setImmediate(function() {
       cb(null, cached);
     });
   else


### PR DESCRIPTION
setImmediate more closely resembles async operations such as db or filesystem calls.

Tested on Windows, node v. 0.10.10

![async-cache-test](https://f.cloud.github.com/assets/1538739/1733035/6e0d5e24-632d-11e3-96ae-867ca816520c.PNG)
