### PR TITLE
Added behavior: returnStaleWhileUpdating

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ var stats = new AsyncCache({
   // options passed directly to the internal lru cache
   max: 1000,
   maxAge: 1000 * 60 * 10,
-  // indicate to lru to return stale (required true for returnStaleWhileUpdating)
+  // indicate to lru to return stale 
+  // (required true for returnStaleWhileUpdating)
   stale: false,
-  // indicate to return immediately (on next tick) the last stale value and not ~block~ (wait) while executing the update function. This option requires stale:true, otherwise it will not have effect. 
+  // indicate to return immediately (on next tick) the last stale value
+  // and not ~block~ (wait) while executing the update function. This option 
+  // requires stale:true, otherwise it will not have effect. 
   returnStaleWhileUpdating: false,
   // method to load a thing if it's not in the cache.
   // key must be unique in the context of this cache.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ var stats = new AsyncCache({
   // options passed directly to the internal lru cache
   max: 1000,
   maxAge: 1000 * 60 * 10,
+  // indicate to lru to return stale (required true for returnStaleWhileUpdating)
+  stale: false,
+  // indicate to return immediately (on next tick) the last stale value and not ~block~ (wait) while executing the update function. This option requires stale:true, otherwise it will not have effect. 
+  returnStaleWhileUpdating: false,
   // method to load a thing if it's not in the cache.
   // key must be unique in the context of this cache.
   load: function (key, cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-cache",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Cache your async lookups and don't fetch the same thing more than necessary.",
   "main": "ac.js",
   "directories": {


### PR DESCRIPTION
Allows not to block after returning the 1st stale object. Will keep returning the last stale object until the load function has returned. The idea behind this is not to stack requests when there is a potentially useful object available to return. The maxAge will trigger the load anyway and the object will be updated eventually.